### PR TITLE
fix: Fix bug preventing instantiation of alt Run key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Built with [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPac
 
 Releases in github repo are packaged for Thunderstore Mod Manager.
 
-* 0.0.9 Allow for custom sprint toggle key to be assigned and used as an alternative to the Shift key (T by default)
+* 0.1.0 Fix bug that prevented alternative Run toggle key from instantiating correctly 
+  * Fix regression bug caused by removing Esc key binding
+* 0.0.9 Allow for custom sprint toggle key to be assigned and used as an alternative to the Run key (T by default)
   * Config AutorunStrafe feature to disable sprinting if Forward key/button pressed
   * Fixes bug that caused a 30% increase in speed while strafing in auto-run
   * Fixes bug that caused null exception after logging back out to the game start screen

--- a/ToggleMovementMod.cs
+++ b/ToggleMovementMod.cs
@@ -14,7 +14,7 @@ namespace ValheimMovementMods
 	{
 		const string pluginGUID = "afilbert.ValheimToggleMovementMod";
 		const string pluginName = "Valheim - Toggle Movement Mod";
-		const string pluginVersion = "0.0.9";
+		const string pluginVersion = "0.1.0";
 		public static ManualLogSource logger;
 
 		private readonly Harmony _harmony = new Harmony(pluginGUID);
@@ -224,11 +224,10 @@ namespace ValheimMovementMods
 			{
 				KeyCode key = (KeyCode)Enum.Parse(typeof(KeyCode), AutorunFreelookKey.Value);
 				__instance.AddButton("Caps", key);
-				if (SprintToggleAlternate.Value)
-				{
-					key = (KeyCode)Enum.Parse(typeof(KeyCode), SprintToggleAlternateKey.Value);
-					__instance.AddButton("Sprint", key);
-				}
+				key = (KeyCode)Enum.Parse(typeof(KeyCode), "Escape");
+				__instance.AddButton("Esc", key);
+				key = (KeyCode)Enum.Parse(typeof(KeyCode), SprintToggleAlternateKey.Value);
+				__instance.AddButton("Sprint", key);
 			}
 		}
 
@@ -258,7 +257,7 @@ namespace ValheimMovementMods
 				bool run;
 				if (SprintToggleAlternate.Value)
 				{
-					run = ZInput.GetButtonUp("Sprint") || ZInput.GetButtonUp(SprintToggleAlternateKey.Value);
+					run = ZInput.GetButtonUp("Sprint");
 				}
 				else
 				{


### PR DESCRIPTION
Also, add back Esc key binding. Removal introduced a regression bug that preventing the auto-run from disabling when Esc key pressed. So, it was used after all...