### PR TITLE
Fix auto-sneak bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Built with [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPac
 
 Releases in github repo are packaged for Thunderstore Mod Manager.
 
+* 1.4.1 Fix auto-sneak bug that got stuck at the stam regen threshold
 * 1.4.0 Support The Bog Witch update. Add auto-attack feature. Optimize the main loop to prevent toggle lock in certain scenarios
 * 1.3.0 Add auto-jump feature and many improvements and tweaks
   * Add label to vanilla Auto-run setting in both Gameplay and Accessibility menus that concisely describes the hover text

--- a/ToggleMovementMod.cs
+++ b/ToggleMovementMod.cs
@@ -18,7 +18,7 @@ namespace ValheimMovementMods
 	{
 		const string pluginGUID = "afilbert.ValheimToggleMovementMod";
 		const string pluginName = "Valheim - Toggle Movement Mod";
-		const string pluginVersion = "1.4.0";
+		const string pluginVersion = "1.4.1";
 		const string freeLookKey = "FreeLook";
 		const string sprintKey = "Sprint";
 
@@ -136,8 +136,7 @@ namespace ValheimMovementMods
 				{
 					Started = true;
 				}
-				if (!SprintSet)
-				{
+				if (!SprintSet && !Crouching) {
 					StaminaRefilling = false;
 				}
 
@@ -259,7 +258,7 @@ namespace ValheimMovementMods
 				{
 					AttackStamRefilling = true;
 				}
-				if (__instance.GetStaminaPercentage() == 1)
+				if (__instance.GetStaminaPercentage() >= 1)
 				{
 					StaminaRefilling = false;
 					JumpStamRefilling = false;


### PR DESCRIPTION
Bug prevented stam refill and essentially prevented the character from auto-sneaking once the stam refill threshold was reached.