### PR TITLE
chore: Bump version due to log cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Built with [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPac
 
 Releases in github repo are packaged for Thunderstore Mod Manager.
 
+* 1.4.2 Clean up debugging logging
 * 1.4.1 Fix auto-sneak bug that got stuck at the stam regen threshold
 * 1.4.0 Support The Bog Witch update. Add auto-attack feature. Optimize the main loop to prevent toggle lock in certain scenarios
 * 1.3.0 Add auto-jump feature and many improvements and tweaks

--- a/ToggleMovementMod.cs
+++ b/ToggleMovementMod.cs
@@ -18,7 +18,7 @@ namespace ValheimMovementMods
 	{
 		const string pluginGUID = "afilbert.ValheimToggleMovementMod";
 		const string pluginName = "Valheim - Toggle Movement Mod";
-		const string pluginVersion = "1.4.1";
+		const string pluginVersion = "1.4.2";
 		const string freeLookKey = "FreeLook";
 		const string sprintKey = "Sprint";
 


### PR DESCRIPTION
This was due to releasing a test version of the binary that had a bunch of debugging log lines in it